### PR TITLE
Update README.md - repo also depends on tactile_image_processing

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ There are four main tasks sharing the same underlying data collection, learning 
 
 ### Installation ###
 
-This work relies on the [Tactile Sim](https://github.com/dexterousrobot/tactile_sim), [Tactile Learning](https://github.com/dexterousrobot/tactile_learning), [Tactile Data](https://github.com/dexterousrobot/tactile_data) and [Tactile Image Processing](https://github.com/dexterousrobot/tactile_image_processing) reposotories. Please follow installation instructions within these repos first.
+This work relies on the [Tactile Sim](https://github.com/dexterousrobot/tactile_sim), [Tactile Learning](https://github.com/dexterousrobot/tactile_learning), [Tactile Data](https://github.com/dexterousrobot/tactile_data), [Common Robot Interface](https://github.com/dexterousrobot/common_robot_interface), [User Input](https://github.com/dexterousrobot/user_input) and [Tactile Image Processing](https://github.com/dexterousrobot/tactile_image_processing) reposotories. Please follow installation instructions within these repos first.
 
 Install Tactile-Gym Servo Control
 

--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ There are four main tasks sharing the same underlying data collection, learning 
 
 ### Installation ###
 
-This work relies on the [Tactile Sim](https://github.com/dexterousrobot/tactile_sim), [Tactile Learning](https://github.com/dexterousrobot/tactile_learning) and [Tactile Data](https://github.com/dexterousrobot/tactile_data) reposotories. Please follow installation instructions within these repos first.
+This work relies on the [Tactile Sim](https://github.com/dexterousrobot/tactile_sim), [Tactile Learning](https://github.com/dexterousrobot/tactile_learning), [Tactile Data](https://github.com/dexterousrobot/tactile_data) and [Tactile Image Processing](https://github.com/dexterousrobot/tactile_image_processing) reposotories. Please follow installation instructions within these repos first.
 
 Install Tactile-Gym Servo Control
 
@@ -111,7 +111,7 @@ Demonstration files are provided for all tasks in the example directory. These u
 To demonstrate servo control, from the base directory run
 
 ```
-python servo_control/servo_control.py -t task_name -d device_name
+python servo_control/launch_servo_control.py -t task_name -d device_name
 ```
 The task can be selected by adjusting the code.
 

--- a/tactile_servo_control/learning/launch_hyper_training.py
+++ b/tactile_servo_control/learning/launch_hyper_training.py
@@ -237,7 +237,7 @@ if __name__ == "__main__":
         val_dirs=['val_data'],
         models=['simple_cnn'],
         model_version=['hyp_temp'],
-        device='cuda'
+        device='cpu'
     )
 
     space = {

--- a/tactile_servo_control/learning/launch_training.py
+++ b/tactile_servo_control/learning/launch_training.py
@@ -105,7 +105,7 @@ if __name__ == "__main__":
         val_dirs=['val_data'],
         models=['simple_cnn'],
         model_version=[''],
-        device='cuda'
+        device='cpu'
     )
 
     launch(args)

--- a/tactile_servo_control/prediction/evaluate_model.py
+++ b/tactile_servo_control/prediction/evaluate_model.py
@@ -141,7 +141,7 @@ if __name__ == "__main__":
         val_dirs=['val_data'],
         models=['simple_cnn'],
         # model_version=[''],
-        device='cuda'
+        device='cpu'
     )
 
     evaluation(args)

--- a/tactile_servo_control/servo_control/launch_servo_control.py
+++ b/tactile_servo_control/servo_control/launch_servo_control.py
@@ -6,6 +6,7 @@ import itertools as it
 import time as t
 import numpy as np
 
+# from tactile_sim.utils.transforms import inv_transform_eul
 from cri.transforms import inv_transform_euler
 from tactile_data.tactile_servo_control import BASE_MODEL_PATH, BASE_RUNS_PATH
 from tactile_image_processing.utils import load_json_obj, make_dir
@@ -65,7 +66,7 @@ def servo_control(
         servo = controller.update(pred_pose)
 
         # new pose applies servo in end effector frame
-        pose = inv_transform_euler(servo, robot.pose)
+        pose = inv_transform_eul(servo, robot.pose)
         robot.move_linear(pose)
 
         # optional peripheral: plot trajectory, reference slider


### PR DESCRIPTION
Through trying to use the repo, I discovered that it also depends in tactile_image_processing and have appended it to the list on the readme.

Changed file name for launching servo control. Not sure that file I've corrected to is the desired file, but the one listed did not exist in that directory.